### PR TITLE
Remove extra whitespace before period in document

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -183,7 +183,7 @@ mouse.release <- function(button = "left") {
 
 #' Move Cursor to Specific Location
 #'
-#' Move cursor to specific coordinate of screen .
+#' Move cursor to specific coordinate of the screen.
 #'
 #' @param x numeric. X-axis of screen.
 #' @param y numeric. Y-axis of screen.

--- a/R/main.R
+++ b/R/main.R
@@ -183,7 +183,7 @@ mouse.release <- function(button = "left") {
 
 #' Move Cursor to Specific Location
 #'
-#' Move cursor to specific coordinate of the screen.
+#' Move cursor to specific coordinate of screen.
 #'
 #' @param x numeric. X-axis of screen.
 #' @param y numeric. Y-axis of screen.


### PR DESCRIPTION
I was reading [the documentation on CRAN](https://cran.r-project.org/web/packages/KeyboardSimulator/KeyboardSimulator.pdf) and saw this type-o: 

<img width="706" alt="image" src="https://github.com/ChiHangChen/KeyboardSimulator/assets/61358854/21cd2274-f59f-4efe-8429-fdf9f4c66ce6">



This PR simply removes this extra whitespace. 

If accepted, the roxygen2 docs will need to be rebuilt. 